### PR TITLE
Remove synchronization from MPU

### DIFF
--- a/mpu.c
+++ b/mpu.c
@@ -36,13 +36,9 @@ void mpu_configure_region(int region, void *addr, size_t len,
     rasr += ((len - 1) << MPU_RASR_SIZE_Pos);
     rasr += MPU_RASR_ENABLE_Msk;
 
-    chSysLock();
-
     /* Update the MPU settings. */
     MPU->RBAR = (uintptr_t)addr + region + MPU_RBAR_VALID_Msk;
     MPU->RASR = rasr;
-
-    chSysUnlock();
 
     /* Make sure the memory barriers are correct. */
     __ISB();

--- a/mpu.h
+++ b/mpu.h
@@ -45,6 +45,7 @@ void mpu_disable(void);
  * @note The lowest 5 bits of the base address are ignored.
  * @warning This function makes the assumption that the region is in memory,
  * not peripheral space (B flag=0).
+ * @warning This function is not thread-safe.
  */
 void mpu_configure_region(int region, void *addr, size_t log2_len,
                           access_permission_t ap, bool executable);


### PR DESCRIPTION
This allows the user to do the locking outside of the MPU driver. This
is required to use it inside interrupts.
